### PR TITLE
Add test to change Pool and Scoring contracts

### DIFF
--- a/src/BCdpManager.t.sol
+++ b/src/BCdpManager.t.sol
@@ -1232,4 +1232,29 @@ contract BCdpManagerTest is BCdpManagerTestBase {
         expectGlobalScore("ETH", expectedInkGlobalScore, expectedArtGlobalScore, 0);
 
     }
+
+    function testFailNonMemberTopupNewPool() public {
+        pool = deployNewPoolContract();
+
+        // No change in score
+        manager.setBParams(address(pool), BCdpScoreLike(address(score)));
+
+        uint cdp = manager.open("ETH", address(this));
+
+        // must fail, as user not allowed to topup externally
+        pool.topup(cdp);
+    }
+
+    function testFailNonMemberUpdateScoreNewScore() public {
+        score = deployNewScoreContract();
+
+        // no change in pool contract
+        manager.setBParams(address(pool), BCdpScoreLike(address(score)));
+
+        uint cdp = manager.open("ETH", address(this));
+
+        // must fail, as user is not allowed to update score externally
+        score.updateScore(cdp, "ETH", 1 ether, 1 ether, now);
+    }
+    
 }

--- a/src/BCdpManager.t.sol
+++ b/src/BCdpManager.t.sol
@@ -260,6 +260,17 @@ contract BCdpManagerTestBase is DssDeployTestBase {
         hevm.warp(currTime);
     }
 
+    function expectScore(uint cdp, bytes32 ilk, uint inkScore, uint artScore, uint slashScore) internal {
+        assertEq(score.getInkScore(cdp, ilk, currTime, score.start()), inkScore);
+        assertEq(score.getArtScore(cdp, ilk, currTime, score.start()), artScore);
+        assertEq(score.getSlashScore(cdp, ilk, currTime, score.start()), slashScore);
+    }
+
+    function expectGlobalScore(bytes32 ilk, uint gInkScore, uint gArtScore, uint gSlashScore) internal {
+        assertEq(score.getInkGlobalScore(ilk, currTime, score.start()), gInkScore);
+        assertEq(score.getArtGlobalScore(ilk, currTime, score.start()), gArtScore);
+        assertEq(score.getSlashGlobalScore(ilk, currTime, score.start()), gSlashScore);
+    }
 }
 
 contract BCdpManagerTest is BCdpManagerTestBase {
@@ -1195,18 +1206,6 @@ contract BCdpManagerTest is BCdpManagerTestBase {
         uint expectedArtGlobalScore = (50 ether + 51 ether) * fwdTimeBy;
         expectGlobalScore("ETH", expectedInkGlobalScore, expectedArtGlobalScore, 0);
 
-    }
-
-    function expectScore(uint cdp, bytes32 ilk, uint inkScore, uint artScore, uint slashScore) internal {
-        assertEq(score.getInkScore(cdp, ilk, currTime, score.start()), inkScore);
-        assertEq(score.getArtScore(cdp, ilk, currTime, score.start()), artScore);
-        assertEq(score.getSlashScore(cdp, ilk, currTime, score.start()), slashScore);
-    }
-
-    function expectGlobalScore(bytes32 ilk, uint gInkScore, uint gArtScore, uint gSlashScore) internal {
-        assertEq(score.getInkGlobalScore(ilk, currTime, score.start()), gInkScore);
-        assertEq(score.getArtGlobalScore(ilk, currTime, score.start()), gArtScore);
-        assertEq(score.getSlashGlobalScore(ilk, currTime, score.start()), gSlashScore);
     }
 
     function testChangePoolAndScoreContracts() public {

--- a/src/BCdpManager.t.sol
+++ b/src/BCdpManager.t.sol
@@ -1192,9 +1192,12 @@ contract BCdpManagerTest is BCdpManagerTestBase {
         manager.setBParams(address(pool), BCdpScoreLike(address(score)));
 
         uint cdp = manager.open("ETH", address(this));
+
+        // expect zero gem before bite
+        assertEq(vat.gem("ETH", address(newJar)), 0);
         reachBite(cdp);
-        assertEq(dai.balanceOf(address(newJar)), 0); //TODO should not be zero
-        assertEq(address(newJar).balance, 0); //TODO should not be zero
+        // expect some balance after bite
+        assert(vat.gem("ETH", address(newJar)) > 0);
 
     }
 


### PR DESCRIPTION
Write the tests for the following:

- [x] Configure new Pool contract in the Manager and perform topup
- [x] Configure new Score contract in the Manger and update score.
- [x] Topup not allowed externally on new Pool contract
- [x] Updatesocre not allowed externally on new Score contract
