### PR TITLE
Calculate available art for a member in separate function and write tests

### DIFF
--- a/src/pool/Pool.sol
+++ b/src/pool/Pool.sol
@@ -300,6 +300,14 @@ contract Pool is Math, DSAuth {
 
         uint numMembers = cdpData[cdp].members.length;
 
-        return sub(cdpData[cdp].art / numMembers, cdpData[cdp].bite[index]);
+        uint maxArt = cdpData[cdp].art / numMembers;
+        // give dust to first member
+        if(index == 0) {
+            uint dust = cdpData[cdp].art % numMembers;
+            maxArt = add(maxArt, dust);
+        }
+        uint availArt = sub(maxArt, cdpData[cdp].bite[index]);
+        
+        return availArt;
     }
 }

--- a/src/pool/Pool.sol
+++ b/src/pool/Pool.sol
@@ -267,8 +267,8 @@ contract Pool is Math, DSAuth {
 
     function bite(uint cdp, uint dart, uint minInk) external onlyMember returns(uint dMemberInk){
         uint index = getIndex(cdpData[cdp].members, msg.sender);
-        uint availArt = availArt(cdp, index);
-        require(dart <= availArt, "bite: debt-too-small");
+        uint availBite = availBite(cdp, index);
+        require(dart <= availBite, "bite: debt-too-small");
 
         cdpData[cdp].bite[index] = add(cdpData[cdp].bite[index], dart);
 
@@ -290,13 +290,13 @@ contract Pool is Math, DSAuth {
         vat.flux(ilk, address(this), msg.sender, dMemberInk);
     }
 
-    function availArt(uint cdp, address member) public returns (uint) {
+    function availBite(uint cdp, address member) public view returns (uint) {
         uint index = getIndex(cdpData[cdp].members, member);
-        return availArt(cdp, index);
+        return availBite(cdp, index);
     }
 
-    function availArt(uint cdp, uint index) internal returns (uint) {
-        require(index < uint(-1), "bite: member-not-elgidabe");
+    function availBite(uint cdp, uint index) internal view returns (uint) {
+        if(index == uint(-1)) return 0;
 
         uint numMembers = cdpData[cdp].members.length;
 

--- a/src/pool/Pool.sol
+++ b/src/pool/Pool.sol
@@ -267,11 +267,7 @@ contract Pool is Math, DSAuth {
 
     function bite(uint cdp, uint dart, uint minInk) external onlyMember returns(uint dMemberInk){
         uint index = getIndex(cdpData[cdp].members, msg.sender);
-        require(index < uint(-1), "bite: member-not-elgidabe");
-
-        uint numMembers = cdpData[cdp].members.length;
-
-        uint availArt = sub(cdpData[cdp].art / numMembers, cdpData[cdp].bite[index]);
+        uint availArt = availArt(cdp, index);
         require(dart <= availArt, "bite: debt-too-small");
 
         cdpData[cdp].bite[index] = add(cdpData[cdp].bite[index], dart);
@@ -292,5 +288,18 @@ contract Pool is Math, DSAuth {
 
         vat.flux(ilk, address(this), jar, userInk);
         vat.flux(ilk, address(this), msg.sender, dMemberInk);
+    }
+
+    function availArt(uint cdp, address member) public returns (uint) {
+        uint index = getIndex(cdpData[cdp].members, member);
+        return availArt(cdp, index);
+    }
+
+    function availArt(uint cdp, uint index) internal returns (uint) {
+        require(index < uint(-1), "bite: member-not-elgidabe");
+
+        uint numMembers = cdpData[cdp].members.length;
+
+        return sub(cdpData[cdp].art / numMembers, cdpData[cdp].bite[index]);
     }
 }

--- a/src/pool/Pool.t.sol
+++ b/src/pool/Pool.t.sol
@@ -955,7 +955,7 @@ contract PoolTest is BCdpManagerTestBase {
         assertEq(vat.gem("ETH",address(jar)),(104 ether * uint(11) * 11/ 1400)/500 - 1);
     }
 
-    function testAvailArtWithDust() public {
+    function testAvailBiteWithDust() public {
         timeReset();
 
         members[0].doDeposit(pool,1000 ether * RAY);
@@ -968,18 +968,18 @@ contract PoolTest is BCdpManagerTestBase {
 
         members[3].doTopup(pool,cdp);
 
-        uint expectedAvailArt = daiAmt / members.length;
+        uint expectedAvailBite = daiAmt / members.length;
         uint expectedDust = daiAmt % members.length;
-        assertEq(pool.availArt(cdp, address(members[0])), expectedAvailArt + expectedDust);
-        assertEq(pool.availArt(cdp, address(members[1])), expectedAvailArt);
-        assertEq(pool.availArt(cdp, address(members[2])), expectedAvailArt);
-        assertEq(pool.availArt(cdp, address(members[3])), expectedAvailArt);
+        assertEq(pool.availBite(cdp, address(members[0])), expectedAvailBite + expectedDust);
+        assertEq(pool.availBite(cdp, address(members[1])), expectedAvailBite);
+        assertEq(pool.availBite(cdp, address(members[2])), expectedAvailBite);
+        assertEq(pool.availBite(cdp, address(members[3])), expectedAvailBite);
 
-        assertEq(members.length * expectedAvailArt + expectedDust, daiAmt);
+        assertEq(members.length * expectedAvailBite + expectedDust, daiAmt);
     }
 
 
-    function testAvailArtWithoutDust() public {
+    function testAvailBiteWithoutDust() public {
         timeReset();
 
         members[0].doDeposit(pool,1000 ether * RAY);
@@ -992,16 +992,16 @@ contract PoolTest is BCdpManagerTestBase {
 
         members[3].doTopup(pool,cdp);
 
-        uint expectedAvailArt = daiAmt / members.length;
+        uint expectedAvailBite = daiAmt / members.length;
         uint expectedDust = daiAmt % members.length;
         assertEq(expectedDust, 0);
 
-        assertEq(pool.availArt(cdp, address(members[0])), expectedAvailArt);
-        assertEq(pool.availArt(cdp, address(members[1])), expectedAvailArt);
-        assertEq(pool.availArt(cdp, address(members[2])), expectedAvailArt);
-        assertEq(pool.availArt(cdp, address(members[3])), expectedAvailArt);
+        assertEq(pool.availBite(cdp, address(members[0])), expectedAvailBite);
+        assertEq(pool.availBite(cdp, address(members[1])), expectedAvailBite);
+        assertEq(pool.availBite(cdp, address(members[2])), expectedAvailBite);
+        assertEq(pool.availBite(cdp, address(members[3])), expectedAvailBite);
 
-        assertEq(members.length * expectedAvailArt, daiAmt);
+        assertEq(members.length * expectedAvailBite, daiAmt);
     }
 
 
@@ -1031,14 +1031,14 @@ contract PoolTest is BCdpManagerTestBase {
         this.file(address(cat), "ETH", "chop", WAD + WAD/10);
         pool.setProfitParams(2,100); // 2% goes to jar
 
-        uint expectedAvailArt = daiAmt / members.length;
+        uint expectedAvailBite = daiAmt / members.length;
         uint expectedDust = daiAmt % members.length;
         assertEq(expectedDust, 3);
 
-        assertEq(pool.availArt(cdp, address(members[0])), expectedAvailArt + expectedDust);
-        assertEq(pool.availArt(cdp, address(members[1])), expectedAvailArt);
-        assertEq(pool.availArt(cdp, address(members[2])), expectedAvailArt);
-        assertEq(pool.availArt(cdp, address(members[3])), expectedAvailArt);
+        assertEq(pool.availBite(cdp, address(members[0])), expectedAvailBite + expectedDust);
+        assertEq(pool.availBite(cdp, address(members[1])), expectedAvailBite);
+        assertEq(pool.availBite(cdp, address(members[2])), expectedAvailBite);
+        assertEq(pool.availBite(cdp, address(members[3])), expectedAvailBite);
 
         // for 26 ether we expect 26/140 * 1.1 = 28.6/140, from which 98% goes to member
         uint expectedEth = uint(98) * 286 ether * 11/ (140 * 100 * 10 * 10);
@@ -1049,10 +1049,10 @@ contract PoolTest is BCdpManagerTestBase {
         members[2].doPoolBite(pool,cdp,amt,expectedEth);
         members[3].doPoolBite(pool,cdp,amt,expectedEth);
 
-        assertEq(pool.availArt(cdp, address(members[0])), 0);
-        assertEq(pool.availArt(cdp, address(members[1])), 0);
-        assertEq(pool.availArt(cdp, address(members[2])), 0);
-        assertEq(pool.availArt(cdp, address(members[3])), 0);
+        assertEq(pool.availBite(cdp, address(members[0])), 0);
+        assertEq(pool.availBite(cdp, address(members[1])), 0);
+        assertEq(pool.availBite(cdp, address(members[2])), 0);
+        assertEq(pool.availBite(cdp, address(members[3])), 0);
 
         // jar should get 2% from 104 * 1.1 * 1.1 / 140
         almostEqual(vat.gem("ETH",address(jar)),(daiAmt * uint(11) * 11/ 1400)/500 - 1);


### PR DESCRIPTION
- [x] Calculate available art for a member in a separate public function. So that member can also call this function offchain.
- [x] Give any dust art amount left to first member in the list.
- [x] Write test for public offchain function.
- [x] Write test to check that in liquidation no dust left in the contract

